### PR TITLE
fix 'Provided signature is invalid' error

### DIFF
--- a/py3cw/request.py
+++ b/py3cw/request.py
@@ -48,7 +48,7 @@ class Py3CW:
                     'APIKEY': self.key,
                     'Signature': signature
                 },
-                data=payload
+                json=payload
             )
 
             response_json = json.loads(response.text)

--- a/py3cw/request.py
+++ b/py3cw/request.py
@@ -7,7 +7,12 @@ from .utils import verify_request
 from requests.exceptions import HTTPError
 
 
-class Py3CW:
+class IPy3CW:
+    def request(self, entity: str, action: str = '', action_id: str = None, payload: any = None):
+        pass
+
+
+class Py3CW(IPy3CW):
 
     def __init__(self, key: str, secret: str):
         """

--- a/py3cw/request.py
+++ b/py3cw/request.py
@@ -5,6 +5,7 @@ import json
 from .config import API_URL, API_VERSION, API_METHODS
 from .utils import verify_request
 from requests.exceptions import HTTPError
+from urllib.parse import urlencode
 
 
 class IPy3CW:
@@ -79,6 +80,11 @@ class Py3CW(IPy3CW):
         method, api_path = api
         api_path = api_path.replace('{id}', action_id or '')
 
+        if method == 'GET' and payload is not None:
+            params = urlencode(payload)
+        else:
+            params = ''
+
         return self.__make_request(
             http_method=method,
             path='{entity}{separator}{api_path}'.format(
@@ -86,6 +92,6 @@ class Py3CW(IPy3CW):
                 separator='/' if api_path else '',
                 api_path=api_path or ''
             ),
-            params='',
+            params=params,
             payload=payload
         )


### PR DESCRIPTION
Hi,

Here is the fix after the recent 3Commas API update today started causing various 'Provided signature is invalid' errors + some of my other changes in order to get this implementation working with various GET's and POST requests 

Regards