### PR TITLE
adding timeout to avoid hang indefinitely waiting for 3c server

### DIFF
--- a/py3cw/request.py
+++ b/py3cw/request.py
@@ -81,7 +81,8 @@ class Py3CW(IPy3CW):
                     'APIKEY': self.key,
                     'Signature': signature
                 },
-                json=payload
+                json=payload,
+                timeout=(5,10)
             )
 
             response_json = json.loads(response.text)


### PR DESCRIPTION
This PR is to solve the issue #7 and timeout connection when it hangs for any reason.
timeout applies : 5 seconds to connect to the 3c server and 10 seconds to respond for the request.
script testing is running for 24h without interrupts.