### PR TITLE
Fix for exceptions raised before `response_json` is assigned

### DIFF
--- a/py3cw/request.py
+++ b/py3cw/request.py
@@ -130,7 +130,12 @@ class Py3CW(IPy3CW):
         except HTTPError as http_err:
             return {'error': True, 'msg': 'HTTP error occurred: {0}'.format(http_err)}, None
 
-        except Exception:
+        except Exception as generic_exc:
+            if not 'response_json' in locals():
+                return {
+                    'error': True,
+                    'msg': 'Other error occurred: {}'.format(generic_exc.args[0])
+                }, None
             return {'error': True, 'msg': 'Other error occurred: {} {} {}.'.format(
                 response_json.get('error'),
                 response_json.get('error_description'),


### PR DESCRIPTION
Some requests fail before the `response_json` variable is set, causing an unhandled `UnboundLocalError` exception:

<img width="695" alt="Screenshot 2021-10-04 at 20 08 40" src="https://user-images.githubusercontent.com/1196694/135909902-b8bcb573-38c6-4801-bae0-badb9bf0c2cf.png">

This PR handles generic exceptions gracefully. In the future, we can handle specific errors (e.g. `InvalidHeaderError`) with a custom handler.