### PR TITLE
Add marketplace bot presets

### DIFF
--- a/py3cw/config.py
+++ b/py3cw/config.py
@@ -78,7 +78,8 @@ API_METHODS = {
     },
     'marketplace': {
         'items': ('GET', 'items'),
-        'signals': ('GET', '{id}/signals')
+        'signals': ('GET', '{id}/signals'),
+        'presets': ('GET', 'presets')
     },
     # smart_trades has been deprecated
     # Please don't use it anymore. Left here only for history reference


### PR DESCRIPTION
Thanks for this module. I'm adding a missing marketplace/presets. Find out more tine [3commas docs](https://github.com/3commas-io/3commas-official-api-docs/blob/master/marketplace_api.md#marketplace-presets-permission-none-security-signed)

### Test with payload e.g.:

```
error, data = p3cw.request(
            entity='marketplace',
            action="presets",
            payload={
                "sort_direction": "asc",
                "sort_by": "profit_per_month"
            }
        )

print(data)
```
Expected: It should give you a list of order by highest profit per month.


